### PR TITLE
Puppet 4 and line-endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Checking out this repo on a windows machine and 
+# trying to run scripts in a booting vm with shared folders can lead to line-ending madness.
+# Stop git converting line-endings with:
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # trying to run scripts in a booting vm with shared folders can lead to line-ending madness.
 # Stop git converting line-endings with:
 *.sh text eol=lf
+*.cfg text eol=lf

--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -63,18 +63,28 @@ install_salt()
 
 install_puppet()
 {
-    echo "==> Installing Puppet"
     REDHAT_MAJOR_VERSION=$(egrep -Eo 'release ([0-9][0-9.]*)' /etc/redhat-release | cut -f2 -d' ' | cut -f1 -d.)
 
+    case ${CM_VERSION:-} in
+        4.* ) CM_PC_VERSION="PC1"
+              RPM_URL="https://yum.puppetlabs.com/puppetlabs-release-${CM_PC_VERSION}-el-${REDHAT_MAJOR_VERSION}.noarch.rpm"
+              PUPPET_PACKAGE="puppet-agent"
+              ;;
+        * )   RPM_URL="https://yum.puppetlabs.com/puppetlabs-release-el-${REDHAT_MAJOR_VERSION}.noarch.rpm" 
+              PUPPET_PACKAGE="puppet"
+              ;;
+    esac
+    
+    echo "==> Installing Puppet"
     echo "==> Installing Puppet Labs repositories"
-    rpm -ipv "http://yum.puppetlabs.com/puppetlabs-release-el-${REDHAT_MAJOR_VERSION}.noarch.rpm"
+    rpm -ipv $RPM_URL
 
     if [[ ${CM_VERSION:-} == 'latest' ]]; then
         echo "==> Installing latest Puppet version"
-        yum -y install puppet
+        yum -y install "${PUPPET_PACKAGE}"
     else
         echo "==> Installing Puppet version ${CM_VERSION}"
-        yum -y install "puppet-${CM_VERSION}"
+        yum -y install "${PUPPET_PACKAGE}-${CM_VERSION}"
     fi
 }
 

--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -66,7 +66,7 @@ install_puppet()
     REDHAT_MAJOR_VERSION=$(egrep -Eo 'release ([0-9][0-9.]*)' /etc/redhat-release | cut -f2 -d' ' | cut -f1 -d.)
 
     case ${CM_VERSION:-} in
-        4.* ) CM_PC_VERSION="PC1"
+        4.* ) CM_PC_VERSION="pc1"
               RPM_URL="https://yum.puppetlabs.com/puppetlabs-release-${CM_PC_VERSION}-el-${REDHAT_MAJOR_VERSION}.noarch.rpm"
               PUPPET_PACKAGE="puppet-agent"
               ;;

--- a/script/cmtool.sh
+++ b/script/cmtool.sh
@@ -9,13 +9,22 @@
 #   'puppet'          -- build a box with the Puppet
 #
 # Values for CM_VERSION can be (when CM is chef|salt|puppet):
-#   'x.y.z'           -- build a box with version x.y.z of Chef
+#   'x.y.z'           -- build a box with version x.y.z of Chef or Puppet
 #   'x.y'             -- build a box with version x.y of Salt
+#   'x' (x >=4)       -- build a box with the latest version x.y.z of Puppet
 #   'latest'          -- build a box with the latest version
 #
 # Set CM_VERSION to 'latest' if unset because it can be problematic
 # to set variables in pairs with Packer (and Packer does not support
 # multi-value variables).
+#
+# Note that for versions of puppet >=4.0.0, not only does the name of 
+# package used to install Puppet change, but the version of that package
+# no longer reflects the actual version of Puppet.
+# See https://docs.puppet.com/puppet/latest/reference/about_agent.html
+# Specifying cm_version=4.x.y should work, where this script has been 
+# updated with the details of that release.
+# Specifying cm_version=4 will install the latest version of Puppet >= 4.0.0.
 CM_VERSION=${CM_VERSION:-latest}
 
 #
@@ -66,9 +75,24 @@ install_puppet()
     REDHAT_MAJOR_VERSION=$(egrep -Eo 'release ([0-9][0-9.]*)' /etc/redhat-release | cut -f2 -d' ' | cut -f1 -d.)
 
     case ${CM_VERSION:-} in
-        4.* ) CM_PC_VERSION="pc1"
+        4* ) CM_PC_VERSION="pc1"
               RPM_URL="https://yum.puppetlabs.com/puppetlabs-release-${CM_PC_VERSION}-el-${REDHAT_MAJOR_VERSION}.noarch.rpm"
               PUPPET_PACKAGE="puppet-agent"
+              case ${CM_VERSION} in
+                      4) CM_VERSION="latest" ;;
+                  4.4.2) CM_VERSION="1.4.2" ;;
+                  4.4.1) CM_VERSION="1.4.1" ;;
+                  4.4.0) CM_VERSION="1.4.0" ;;
+                  4.3.2) CM_VERSION="1.3.6" ;;
+                  4.3.1) CM_VERSION="1.3.2" ;;
+                  4.3.0) CM_VERSION="1.3.0" ;;
+                  4.2.3) CM_VERSION="1.2.7" ;;
+                  4.2.2) CM_VERSION="1.2.6" ;;
+                  4.2.1) CM_VERSION="1.2.2" ;;
+                  4.2.0) CM_VERSION="1.2.1" ;;
+                  4.1.0) CM_VERSION="1.1.1" ;;
+                  4.0.0) CM_VERSION="1.0.1" ;;
+              esac
               ;;
         * )   RPM_URL="https://yum.puppetlabs.com/puppetlabs-release-el-${REDHAT_MAJOR_VERSION}.noarch.rpm" 
               PUPPET_PACKAGE="puppet"


### PR DESCRIPTION
This PR attempts to resolve the same problems as two existing, but unaccepted PRs: https://github.com/boxcutter/centos/pull/20 and https://github.com/boxcutter/centos/pull/28.

https://github.com/boxcutter/centos/pull/20 is about the introduction of a new package naming versiong scheme for the official Puppet packages with version 4 of the Puppet language. See https://docs.puppet.com/puppet/latest/reference/about_agent.html for details. That PR introduces a new type CM_VERSION to handle this. This PR uses logic within the script to translate puppet versions to puppet-agent versions. This should be more transparent, but will require updating each time a new release of the puppet-agent packages comes out. We have got the option of simply specifying '4' as the version of Puppet to install to get the latest 4.y.z version, however.

https://github.com/boxcutter/centos/pull/28 relates to problems with sudo when running packer on Windows. Although the error message given refers to needing a tty, the root cause of this appears to be to do with line endings in the files checked out on Windows. By default, git has [core.autocrlf=true](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace) on Windows. When these files are then used by a Linux VM - particularly anything to do with sudo, bad things happen. The ks7.cfg kickstart script should remove the requirement to have a tty from /etc/sudoers, but this fails when the .cfg file has Windows-style line-endings in it. Using a .gitattributes file to force LF line-endings on relevant files fixes this.
